### PR TITLE
168681746 correct reload command to work with redis cache

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -306,7 +306,9 @@ Gateway.prototype.reload = (options) => {
     socket.on('connect', () => {
         edgeconfig.get({
             source: source,
-            keys: keys
+            keys: keys,
+            org: options.org,
+            env: options.env
         }, (err, config) => {
             if (err) {
                 const exists = fs.existsSync(cache);


### PR DESCRIPTION
Pass org and env in options to config.get to make avialable for generating redis keys